### PR TITLE
Fix bug introduced with Erlang typed record fields

### DIFF
--- a/src/pp_record.erl
+++ b/src/pp_record.erl
@@ -84,6 +84,8 @@ record_fields([{record_field,_,{atom,_,Field}} | Fs]) ->
     [Field | record_fields(Fs)];
 record_fields([{record_field,_,{atom,_,Field},_} | Fs]) ->
     [Field | record_fields(Fs)];
+record_fields([{typed_record_field,Field,_Type} | Fs]) ->
+    record_fields([Field | Fs]);
 record_fields([]) ->
     [].
 


### PR DESCRIPTION
This problem was introduced already with Erlang vsn 19 since they introduced typed record fields   (see OTP-13148).

The problem was that we didn't get any output for some records.
